### PR TITLE
Complete `package.json` for NPM

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,8 +1,18 @@
 {
+    "private": true,
     "type": "module",
+    "name": "jb2a-databases",
     "scripts": {
         "build": "npm run build:free && npm run build:patreon",
         "build:free": "node ./JB2A_DnD5e/generateJSON.js",
         "build:patreon": "node ./jb2a_patreon/generateJSON.js"
-    }
+    },
+    "description": "Database for our modules (Free and Patreon)",
+    "version": "1.0.0",
+    "license": "ISC",
+    "repository": {
+        "type": "git",
+        "url": "https://github.com/Jules-Bens-Aa/jb2a-databases"
+    },
+    "homepage": "https://jb2a.com/"
 }


### PR DESCRIPTION
The `name` and `version` fields are mandatory for the package to be used as an NPM package (personally, for [pf2e-graphics](https://github.com/MrVauxs/pf2e-graphics)). I set `private` since I presume you don't actually want to publish to NPM itself.

The other fields are all optional, but I thought it'd be nice to put them in anyway ¯\\\_(ツ)_/¯