### PR TITLE
Add module exports

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+node_modules/

--- a/index.d.ts
+++ b/index.d.ts
@@ -1,0 +1,4 @@
+export { default as databaseFree } from "./JB2A_DnD5e/json/animations-object.json";
+export { default as databasePathsFree } from "./JB2A_DnD5e/json/database-paths.json";
+export { default as databasePatreon } from "./jb2a_patreon/json/animations-object.json";
+export { default as databasePathsPatreon } from "./jb2a_patreon/json/database-paths.json";

--- a/index.js
+++ b/index.js
@@ -1,0 +1,4 @@
+export { default as databaseFree } from "./JB2A_DnD5e/json/animations-object.json" with { type: "json" };
+export { default as databasePathsFree } from "./JB2A_DnD5e/json/database-paths.json" with { type: "json" };
+export { default as databasePatreon } from "./jb2a_patreon/json/animations-object.json" with { type: "json" };
+export { default as databasePathsPatreon } from "./jb2a_patreon/json/database-paths.json" with { type: "json" };

--- a/index.ts
+++ b/index.ts
@@ -1,0 +1,4 @@
+export { default as databaseFree } from "./JB2A_DnD5e/json/animations-object.json" with { type: "json" };
+export { default as databasePathsFree } from "./JB2A_DnD5e/json/database-paths.json" with { type: "json" };
+export { default as databasePatreon } from "./jb2a_patreon/json/animations-object.json" with { type: "json" };
+export { default as databasePathsPatreon } from "./jb2a_patreon/json/database-paths.json" with { type: "json" };

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,0 +1,30 @@
+{
+    "name": "jb2a-databases",
+    "version": "1.0.0",
+    "lockfileVersion": 3,
+    "requires": true,
+    "packages": {
+        "": {
+            "name": "jb2a-databases",
+            "version": "1.0.0",
+            "license": "ISC",
+            "devDependencies": {
+                "typescript": "^5.5.4"
+            }
+        },
+        "node_modules/typescript": {
+            "version": "5.5.4",
+            "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.5.4.tgz",
+            "integrity": "sha512-Mtq29sKDAEYP7aljRgtPOpTvOfbwRWlS6dPRzwjdE+C0R4brX/GUyhHSecbHMFLNBLcJIPt9nl9yG5TZ1weH+Q==",
+            "dev": true,
+            "license": "Apache-2.0",
+            "bin": {
+                "tsc": "bin/tsc",
+                "tsserver": "bin/tsserver"
+            },
+            "engines": {
+                "node": ">=14.17"
+            }
+        }
+    }
+}

--- a/package.json
+++ b/package.json
@@ -3,9 +3,14 @@
     "type": "module",
     "name": "jb2a-databases",
     "scripts": {
-        "build": "npm run build:free && npm run build:patreon",
+        "build": "tsc && npm run build:free && npm run build:patreon",
         "build:free": "node ./JB2A_DnD5e/generateJSON.js",
         "build:patreon": "node ./jb2a_patreon/generateJSON.js"
+    },
+    "exports": "./index.js",
+	 "types": "./index.d.ts",
+    "devDependencies": {
+        "typescript": "^5.5.4"
     },
     "description": "Database for our modules (Free and Patreon)",
     "version": "1.0.0",

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,0 +1,17 @@
+{
+	"compilerOptions": {
+		"strict": true,
+		"alwaysStrict": true,
+		"noImplicitAny": true,
+		"noImplicitReturns": true,
+
+		"module": "NodeNext",
+		"target": "ESNext",
+
+		"declaration": true,
+		"noEmitOnError": true,
+
+		"verbatimModuleSyntax": true,
+		"resolveJsonModule": true
+	}
+}


### PR DESCRIPTION
Me again!

Realised a couple extra things needed to be added for a variety of reasons. The net result is that developers can now `import { ... } from 'jb2a-databases';` in both JS and TS. Besides you needing to run `npm install` once on your end, there's no other impact; `npm run build` will continue to handle everything automatically.